### PR TITLE
Correct pg_hba.conf lines for obm-ui, obm-sync and obm-autoconf roles. 

### DIFF
--- a/roles/obm-autoconf/templates/03-remote-obm-autoconf
+++ b/roles/obm-autoconf/templates/03-remote-obm-autoconf
@@ -1,1 +1,1 @@
-host    {{ obm_db_name }}             {{ obm_db_user }}             {{ ansible_default_ipv4['address'] }}/32           md5
+host    {{ obm_db_name }}             {{ obm_db_user }}             {{ ansible_default_ipv4['address'] }}/32            md5

--- a/roles/obm-db-pg/tasks/database.yml
+++ b/roles/obm-db-pg/tasks/database.yml
@@ -8,7 +8,7 @@
   assemble: src={{ pgdatadir }}/pg_hba.d dest={{ pgdatadir }}/pg_hba.conf
   delegate_to: "{{ obm_db_master_host }}"
   notify: Reload Postgres
-  meta: flush_handlers
+#  meta: flush_handlers
   tags: obm-db
 
 

--- a/roles/obm-sync/templates/03-remote-obm-sync
+++ b/roles/obm-sync/templates/03-remote-obm-sync
@@ -1,1 +1,1 @@
-host    {{ obm_db_name }}             {{ obm_db_user }}             {{ ansible_default_ipv4['address'] }}/32           md5
+host    {{ obm_db_name }}             {{ obm_db_user }}             {{ ansible_default_ipv4['address'] }}/32            md5

--- a/roles/obm-ui/templates/03-remote-obm-ui
+++ b/roles/obm-ui/templates/03-remote-obm-ui
@@ -1,1 +1,1 @@
-host    {{ obm_db_name }}             {{ obm_db_user }}             {{ ansible_default_ipv4['address'] }}/32        md5
+host    {{ obm_db_name }}             {{ obm_db_user }}             {{ ansible_default_ipv4['address'] }}/32            md5


### PR DESCRIPTION
Removing flush_handlers in Merge PostgreSQL configuration files task (#25) causes it doesn't execute
