### PR TITLE
Update cyrus-commmon role

### DIFF
--- a/roles/cyrus-common/files/pam
+++ b/roles/cyrus-common/files/pam
@@ -1,0 +1,7 @@
+#%PAM-1.0 
+auth            sufficient      /lib64/security/pam_ldap.so config=/etc/pam_ldap_obm.conf
+auth            sufficient      /lib64/security/pam_unix.so
+auth            required        /lib64/security/pam_pwhistory.so shadow nullok
+account         sufficient      /lib64/security/pam_ldap.so
+account         sufficient      /lib64/security/pam_unix.so
+account         required        /lib64/security/pam_pwhistory.so shadow nullok

--- a/roles/cyrus-common/meta/main.yml
+++ b/roles/cyrus-common/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+ - { role: sasl }

--- a/roles/cyrus-common/tasks/main.yml
+++ b/roles/cyrus-common/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
 - include: packages.yml
-- include: flush.yml
+- include: pam.yml
 - include: config.yml
+- include: flush.yml

--- a/roles/cyrus-common/tasks/pam.yml
+++ b/roles/cyrus-common/tasks/pam.yml
@@ -1,0 +1,14 @@
+---
+- name: Deploy pam configuration
+  copy: src=pam dest=/etc/pam.d/{{ item }}
+  with_items:
+   - imap
+   - sieve
+   - mupdate
+  when: sasl_backend == "pam"
+  notify:
+   - Restart saslauthd
+  tags: cyrus-backend
+
+- name: Debug
+  debug: msg="What the fuck {{ sasl_ldap_ssl }}"


### PR DESCRIPTION
Cyrus-common role is responsible about the pam files deployment and not the sasl role.
If the sasl_backend is set to pam, it deploys them otherwise it deploys saslauthd.conf
