### PR TITLE
Adapt the replication factor to the count of cassandra servers

### DIFF
--- a/roles/cassandra/templates/init.cql
+++ b/roles/cassandra/templates/init.cql
@@ -1,2 +1,2 @@
-CREATE KEYSPACE IF NOT EXISTS {{ cassandra_keyspace }} WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor': 1};
+CREATE KEYSPACE IF NOT EXISTS {{ cassandra_keyspace }} WITH REPLICATION = {'class' : 'SimpleStrategy', 'replication_factor': {{ groups['cassandraservers'] | length }} };
 CREATE USER IF NOT EXISTS {{ cassandra_user }} WITH PASSWORD '{{ cassandra_password }}' SUPERUSER;


### PR DESCRIPTION
When you chose to have 3 cassandra servers in your OBM env, you often want to replication all your data on each of them.